### PR TITLE
Fix phases

### DIFF
--- a/examples/override-phase/default.nix
+++ b/examples/override-phase/default.nix
@@ -20,6 +20,9 @@ let
 
     # `runHook` is used to let downstream users run `preBuild` and `postBuild` hooks
     # see https://nixos.org/manual/nixpkgs/stable/#sec-stdenv-phases
+
+    # `./`-prefixed packages are used due to `package-spec` for folders
+    # https://docs.npmjs.com/cli/v10/using-npm/package-spec#folders
     buildPhase = ''
       runHook preBuild
 

--- a/examples/override-phase/default.nix
+++ b/examples/override-phase/default.nix
@@ -18,7 +18,11 @@ let
       pangomm
     ];
 
+    # `runHook` is used to let downstream users run `preBuild` and `postBuild` hooks
+    # see https://nixos.org/manual/nixpkgs/stable/#sec-stdenv-phases
     buildPhase = ''
+      runHook preBuild
+
       echo "Rebuilding node_modules with patched shebangs and install scripts..."
 
       rm ./node_modules/.bin/node-pre-gyp
@@ -36,6 +40,8 @@ let
       }"
 
       npm rebuild --offline "$PACKAGES"
+
+      runHook postBuild
     '';
   });
 in

--- a/examples/override-phase/default.nix
+++ b/examples/override-phase/default.nix
@@ -34,8 +34,7 @@ let
           (x: x.packages)
           builtins.attrNames
           (builtins.filter (x: x != "" && x != "node_modules/@mapbox/node-pre-gyp"))
-          (builtins.map (lib.strings.removePrefix "node_modules/"))
-          (lib.strings.concatStringsSep " ")
+          (lib.strings.concatMapStringsSep " " (x: "./${x}"))
         ]
       }"
 

--- a/lib/slimlock.nix
+++ b/lib/slimlock.nix
@@ -90,9 +90,7 @@
 
       propagatedBuildInputs = [nodejs];
 
-      preBuildPhases = [ "preBuildPhase" ];
-
-      preBuildPhase = ''
+      configurePhase = ''
         export HOME=$PWD/.home
         export npm_config_cache=$PWD/.npm
         export npm_config_jobs="max"


### PR DESCRIPTION
Hi, @thomashoneyman!

After reading about phases in a [nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#sec-stdenv-phases) I decided that:
- `preBuildPhases` should be left to downstream users;
- the example that shows overriding a phase should have `runHook`-s so that downstream users are able to run `preBuild` and `postBuild` hooks.

Additionally, I read about [npm rebuild](https://docs.npmjs.com/cli/v10/commands/npm-rebuild) and [package-spec](https://docs.npmjs.com/cli/v10/using-npm/package-spec#folders) and decided to update package paths used in the `override-phase` example.